### PR TITLE
Async gitops

### DIFF
--- a/gitops/__init__.py
+++ b/gitops/__init__.py
@@ -1,2 +1,2 @@
 name = 'gitops'
-__version__ = '0.1.1'
+__version__ = '0.2.0'

--- a/gitops/core.py
+++ b/gitops/core.py
@@ -82,7 +82,7 @@ def command(ctx, filter, command, exclude='', cleanup=True, sequential=True):
         print(success_negative('Aborted.'))
         return
 
-    if sequential:
+    if sequential or len(apps) == 1:
         for app in apps:
             # For each app, just run the coroutine
             asyncio.run(run_job(app, command, cleanup=cleanup, sequential=sequential))

--- a/gitops/core.py
+++ b/gitops/core.py
@@ -1,8 +1,10 @@
+import asyncio
 from invoke import run, task
 
 from colorama import Fore
 
 from gitops.utils.apps import get_apps, update_app
+from gitops.utils.async_runner import run_tasks_async_with_progress
 from gitops.utils.cli import colourise, success, success_negative
 from gitops.utils.exceptions import AppOperationAborted
 from gitops.utils.images import colour_image, get_image, get_latest_image
@@ -69,7 +71,7 @@ def bump(ctx, filter, exclude='', image_tag=None, prefix=None, autoexclude_inact
 
 
 @task
-def command(ctx, filter, command, exclude='', cleanup=True):
+def command(ctx, filter, command, exclude='', cleanup=True, sequential=True):
     """ Run command on selected app(s).
 
         eg. inv command customer,sandbox -e aesg "python manage.py migrate"
@@ -79,8 +81,16 @@ def command(ctx, filter, command, exclude='', cleanup=True):
     except AppOperationAborted:
         print(success_negative('Aborted.'))
         return
-    for app in apps:
-        run_job(app, command, cleanup=cleanup)
+
+    if sequential:
+        for app in apps:
+            # For each app, just run the coroutine
+            asyncio.run(run_job(app, command, cleanup=cleanup, sequential=sequential))
+    else:
+        # Build list of coroutines, and execute them all at once
+        jobs = [(run_job(app, command, cleanup=cleanup, sequential=sequential), app['name']) for app in apps]
+        asyncio.run(run_tasks_async_with_progress(jobs))
+
     print(success('Done!'))
 
 

--- a/gitops/db.py
+++ b/gitops/db.py
@@ -1,3 +1,4 @@
+import asyncio
 from invoke import task
 
 from gitops.utils import kube
@@ -14,7 +15,7 @@ def backup(ctx, app):
         'name': f'{app}-backup',
         'app': app
     }
-    kube._run_job('jobs/backup-job.yml', values, 'workforce')
+    asyncio.run(kube._run_job('jobs/backup-job.yml', values, 'workforce', sequential=True))
 
 
 @task
@@ -33,7 +34,7 @@ def restore_backup(ctx, app, index):
         'timestamp': backup[0],
         'app': app
     }
-    kube._run_job('jobs/restore-job.yml', values, 'workforce')
+    asyncio.run(kube._run_job('jobs/restore-job.yml', values, 'workforce'))
 
 
 @task
@@ -46,9 +47,9 @@ def copy_db(ctx, source, destination, skip_backup=False, cleanup=True):
         'destination': destination,
         'skip_backup': 'skip' if skip_backup else ''
     }
-    kube._run_job('jobs/copy-db-job.yml', values, 'workforce', cleanup=cleanup)
+    asyncio.run(kube._run_job('jobs/copy-db-job.yml', values, 'workforce', cleanup=cleanup))
     print(progress('You may want to clear the redis cache now!'))
-    print(progress(f'\t- inv mcommand {destination} clear_cache'))
+    print(progress(f'\t- gitops mcommand {destination} clear_cache'))
 
 
 @task

--- a/gitops/shorthands.py
+++ b/gitops/shorthands.py
@@ -1,22 +1,20 @@
+import asyncio
 from invoke import task
 
-from colorama import Fore
-
-from gitops.utils.apps import get_app_details, get_apps
-from gitops.utils.cli import colourise, success
+from gitops.utils.apps import get_app_details
+from gitops.utils.cli import success
 from gitops.utils.kube import run_job
 
 from .core import command
-from .newtenant import create_archiver_ses
 
 
 @task
-def mcommand(ctx, filter, mcommand, exclude='', cleanup=True):
+def mcommand(ctx, filter, mcommand, exclude='', cleanup=True, sequential=False):
     """ Run django management command on selected app(s).
 
         eg. inv mcommand customer,sandbox -e aesg showmigrations
     """
-    return command(ctx, filter, f'python manage.py {mcommand}', exclude=exclude, cleanup=cleanup)
+    return command(ctx, filter, f'python manage.py {mcommand}', exclude=exclude, cleanup=cleanup, sequential=sequential)
 
 
 @task(aliases=['sp'])
@@ -26,7 +24,7 @@ def shell_plus(ctx, app, cleanup=True):
         eg. inv sp aesg
     """
     app = get_app_details(app)
-    run_job(app, 'python manage.py shell_plus', cleanup=cleanup)
+    asyncio.run(run_job(app, 'python manage.py shell_plus', cleanup=cleanup))
     print(success('Done!'))
 
 
@@ -36,16 +34,4 @@ def migrate(ctx, filter, exclude='', cleanup=True):
 
         eg. inv migrate workforce,sandbox
     """
-    for app in get_apps(filter=filter, exclude=exclude, mode='PREVIEW', message=f"{colourise('Migrations triggered to run on the following apps:', Fore.LIGHTBLUE_EX)}"):
-        run_job(app, 'python manage.py migrate', cleanup=cleanup)
-    print(success('Done!'))
-
-
-@task
-def move_to_ses(ctx, filter, exclude='', cleanup=True):
-    """ Creates SES mail rules for selected apps.
-        Temporary command until we finish migrating existing customers.
-    """
-    for app in get_apps(filter=filter, exclude=exclude, message=f"{colourise('SES rules to be created on the following apps:', Fore.LIGHTBLUE_EX)}"):
-        create_archiver_ses(ctx, name=app["name"], create_legacy_route=True)
-    print(success('Done!'))
+    return command(ctx, filter, f'python manage.py migrate', exclude=exclude, cleanup=cleanup, sequential=False)

--- a/gitops/utils/apps.py
+++ b/gitops/utils/apps.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from colorama import Fore
@@ -13,11 +14,15 @@ from .tags import colour_tags, validate_tags
 
 
 def get_app_details(app_name):
-    ns = Namespace(app_name)
     try:
-        ns.from_path(f'apps/{app_name}')
+        ns = Namespace(app_name, path=f'apps/{app_name}')
     except FileNotFoundError:
-        raise AppDoesNotExist(app_name)
+        # Check if apps dir doesn't exist, or just that one app
+        if os.path.exists("apps"):
+            raise AppDoesNotExist(app_name)
+        else:
+            raise AppDoesNotExist()
+
     values = ns.values
     values['name'] = app_name
     return values
@@ -56,7 +61,11 @@ def get_apps(filter=[], exclude=[], mode='PROMPT', autoexclude_inactive=True, me
         exclude.add('inactive')
     apps = []
     existing_tags = set()
-    for entry in sorted(Path('apps').iterdir()):
+    try:
+        directory = sorted(Path('apps').iterdir())
+    except FileNotFoundError:
+        raise AppDoesNotExist()
+    for entry in directory:
         if not entry.is_dir():
             continue
         app = get_app_details(entry.name)

--- a/gitops/utils/async_runner.py
+++ b/gitops/utils/async_runner.py
@@ -40,7 +40,6 @@ async def print_async_complete(task, position, length, just, stdscr):
     green check) depending on if the coroutine raises an exception or not.
     """
     cor, name = task
-    # TODO: Log output of `cor` to a file named f'{name}.log'
     stdscr.addstr(position, 0, name)
     stdscr.refresh()
     output = f'{"-"*20}\n{progress(name)}\n{"-"*20}\n'

--- a/gitops/utils/async_runner.py
+++ b/gitops/utils/async_runner.py
@@ -1,0 +1,75 @@
+import asyncio
+import curses
+from .cli import success, warning, progress
+
+
+def init_curses():
+    stdscr = curses.initscr()
+    curses.start_color()
+    curses.use_default_colors()
+    # -1 is default terminal background color
+    curses.init_pair(1, curses.COLOR_RED, -1)
+    curses.init_pair(2, curses.COLOR_GREEN, -1)
+    curses.noecho()
+    curses.cbreak()
+    # Turn off cursor
+    curses.curs_set(0)
+    return stdscr
+
+
+async def run_tasks_async_with_progress(tasks):
+    stdscr = init_curses()
+    stdscr.addstr(0, 0, 'Your command is now running on the following servers:')
+    # Ugly.
+    just = len(max(tasks, key=lambda x: len(x[1]))[1]) + 1
+    tasks = [print_async_complete(task, num + 1, len(tasks), just, stdscr) for num, task in enumerate(tasks)]
+    outputs = await asyncio.gather(*tasks)
+    stdscr.addstr(len(tasks) + 1, 0, 'Done. Press enter to view the outputs of the commands.')
+    stdscr.refresh()
+    curses.echo()
+    curses.nocbreak()
+    input()
+    curses.endwin()
+    print("\n".join(outputs))
+
+
+async def print_async_complete(task, position, length, just, stdscr):
+    """
+    Move cursor to `position`, print task name, run  task coroutine, then move
+    back to `pos` print message and a justified completion mark (red cross or
+    green check) depending on if the coroutine raises an exception or not.
+    """
+    cor, name = task
+    # TODO: Log output of `cor` to a file named f'{name}.log'
+    stdscr.addstr(position, 0, name)
+    stdscr.refresh()
+    output = f'{"-"*20}\n{progress(name)}\n{"-"*20}\n'
+    try:
+        output += await cor
+    except Exception as e:
+        stdscr.addstr(position, just, '✗', curses.color_pair(1))
+        output += f'Exception: {str(e)}'
+    else:
+        stdscr.addstr(position, just, '✔', curses.color_pair(2))
+    stdscr.refresh()
+    return output
+
+
+async def async_run(cmd):
+    proc = await asyncio.create_subprocess_shell(
+        cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE
+    )
+
+    stdout, stderr = await proc.communicate()
+    return (
+        stdout,
+        stderr,
+        (
+            success('[stdout]\n')
+            + f'{stdout.decode()}\n'
+            + warning('[stderr]\n')
+            + f'{stderr.decode()}\n'
+        )
+    )

--- a/gitops/utils/exceptions.py
+++ b/gitops/utils/exceptions.py
@@ -10,7 +10,11 @@ class AppOperationAborted(Exception):
 class AppDoesNotExist(Exception):
     def __init__(self, app_name):
         # Funky hack to stomp on traceback.
-        self.args = warning(f"There's no app with the name '{app_name}', silly."),
+        if app_name:
+            message = f"There's no app with the name '{app_name}', silly."
+        else:
+            message = f"Could not find an 'apps' directory. Are you in a cluster repo?"
+        self.args = warning(message),
         sys.exit(self)
 
 

--- a/gitops/utils/kube.py
+++ b/gitops/utils/kube.py
@@ -305,7 +305,6 @@ async def _run_job(path, values={}, namespace='default', attach=False, cleanup=T
             resource = resource.replace('{{ %s }}' % k, v)
         tmp.write(resource)
         tmp.flush()
-        # TODO: Do we want to log creating the job?
         await async_run(f'kubectl create -n {namespace} -f {tmp.name}')
         cmd = (
             'kubectl get pods'

--- a/gitops/utils/kube.py
+++ b/gitops/utils/kube.py
@@ -21,10 +21,12 @@ import humanize
 from colorama import Fore
 from gitops_server.namespace import Namespace
 
+from gitops.utils.async_runner import async_run
+
 from .exceptions import CommandError
 
 
-def run_job(app, command, cleanup=True):
+async def run_job(app, command, cleanup=True, sequential=True):
     job_id = make_key(4).lower()
     app_name = app['name']
     values = {
@@ -33,7 +35,7 @@ def run_job(app, command, cleanup=True):
         'command': str(shlex.split(command)),
         'image': app['image'],
     }
-    _run_job('jobs/command-job.yml', values, 'workforce', interactive=True, cleanup=cleanup)
+    return await _run_job('jobs/command-job.yml', values, 'workforce', attach=True, cleanup=cleanup, sequential=sequential)
 
 
 def build_image(local_image, path=None, tag=None):
@@ -294,15 +296,17 @@ def make_key(length=64):
     )
 
 
-def _run_job(path, values={}, namespace='default', interactive=False, cleanup=True):
+async def _run_job(path, values={}, namespace='default', attach=False, cleanup=True, sequential=True):
     name = values['name']
+    logs = ''
     with tempfile.NamedTemporaryFile('wt', suffix='.yml') as tmp:
         resource = open(path, 'r').read()
         for k, v in values.items():
             resource = resource.replace('{{ %s }}' % k, v)
         tmp.write(resource)
         tmp.flush()
-        run(f'kubectl create -n {namespace} -f {tmp.name}', hide=True)
+        # TODO: Do we want to log creating the job?
+        await async_run(f'kubectl create -n {namespace} -f {tmp.name}')
         cmd = (
             'kubectl get pods'
             ' -n {namespace}'
@@ -312,17 +316,16 @@ def _run_job(path, values={}, namespace='default', interactive=False, cleanup=Tr
             name=name,
             namespace=namespace
         )
-        intro = f'Launching job {Fore.BLUE}{name}{Fore.RESET} ... '
-        with run_wrapper(intro):
-            @retry
-            def _find_pod():
-                pod = run(cmd, hide=True).stdout.strip()
-                if not pod:
-                    raise CommandError('Failed to find pod.')
-                return pod
-            pod = _find_pod()
+        @retry
+        async def _find_pod():
+            stdout, _, _ = await async_run(cmd)
+            pod = stdout.decode()
+            if not pod:
+                raise CommandError('Failed to find pod.')
+            return pod
+        pod = await _find_pod()
         try:
-            if not interactive:
+            if not attach:
                 intro = 'Waiting for job to complete ... '
                 with run_wrapper(intro):
                     cmd = (
@@ -332,11 +335,10 @@ def _run_job(path, values={}, namespace='default', interactive=False, cleanup=Tr
                         ' --timeout=-1s'
                         f' job/{name}'
                     )
-                    run(cmd, hide=True)
+                    _, _, output_log = await async_run(cmd)
+                    logs += output_log
             else:
-                intro = 'Waiting for job to start ... '
-                with run_wrapper(intro):
-                    wait_for_pod(namespace, pod)
+                await wait_for_pod(namespace, pod)
                 cmd = (
                     'kubectl attach'
                     f' -n {namespace}'
@@ -344,24 +346,27 @@ def _run_job(path, values={}, namespace='default', interactive=False, cleanup=Tr
                     f' {pod}'
                 )
                 try:
-                    run(cmd, pty=True)
+                    if sequential:
+                        # If we're not running asynchronously, use invoke.run to preserve interactivity for shell_plus, etc.
+                        run(cmd, pty=True)
+                    else:
+                        _, _, output_log = await async_run(cmd)
+                        logs += output_log
+
                 except Exception as e:
                     if 'current phase is Succeeded' not in str(e.result.stdout):
                         raise e
-                    logs = get_pod_logs(namespace, pod)
-                    print(logs)
         except Exception as e:
             if 'current phase is Succeeded' not in str(e.result.stdout):
                 raise e
         finally:
             if cleanup:
-                intro = 'Cleaning up job ... '
-                with run_wrapper(intro):
-                    cmd = f'kubectl delete -n {namespace} job {name}'
-                    run(cmd, hide=True)
+                cmd = f'kubectl delete -n {namespace} job {name}'
+                await async_run(cmd)
+    return logs
 
 
-def wait_for_pod(namespace, pod):
+async def wait_for_pod(namespace, pod):
     while True:
         cmd = (
             'kubectl get pod'
@@ -369,9 +374,10 @@ def wait_for_pod(namespace, pod):
             ' -o jsonpath="{.status.phase}"'
             f' {pod}'
         )
-        result = run(cmd, hide=True)
-        if result.stdout.lower() != 'pending':
-            return result.stdout.lower()
+        stdout, _, _ = await async_run(cmd)
+        stdout = stdout.decode().lower()
+        if stdout != 'pending':
+            return stdout
 
 
 def get_pod_names(namespace, selector):

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'boto',
         'invoke',
         'humanize',
+        'colorama',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Updates gitops commands to run asynchronously when possible.

Defaults to running async for migrate and mcommand, and is available on command by passing --no-sequential.

Preserves interactivity with shell_plus shortcut 'sp'. It is the user's onus not to run interactive commands asynchronously. They will simply hang waiting for input until kube kills the job.

Shows progress of asynchronous commands neatly using curses, returning stdout and stderr, which are formatted nicely and displayed at the end.