### PR TITLE
Multiple cluster support.

### DIFF
--- a/gitops/utils/exceptions.py
+++ b/gitops/utils/exceptions.py
@@ -13,7 +13,7 @@ class AppDoesNotExist(Exception):
         if app_name:
             message = f"There's no app with the name '{app_name}', silly."
         else:
-            message = f"Could not find an 'apps' directory. Are you in a cluster repo?"
+            message = "Could not find an 'apps' directory. Are you in a cluster repo?"
         self.args = warning(message),
         sys.exit(self)
 

--- a/gitops_server/__init__.py
+++ b/gitops_server/__init__.py
@@ -1,9 +1,3 @@
-import os
-import yaml
+from .utils import get_cluster_name
 
-with open(os.getenv('KUBE_CONFIG_FILE'), 'r') as f:
-    _conf = yaml.load(f)
-
-_contexts = {c['name']: c['context'] for c in _conf['contexts']}
-
-CLUSTER_NAME = _contexts[_conf['current-context']]['cluster']
+CLUSTER_NAME = get_cluster_name()

--- a/gitops_server/__init__.py
+++ b/gitops_server/__init__.py
@@ -1,0 +1,9 @@
+import os
+import yaml
+
+with open(os.getenv('KUBE_CONFIG_FILE'), 'r') as f:
+    _conf = yaml.load(f)
+
+_contexts = {c['name']: c['context'] for c in _conf['contexts']}
+
+CLUSTER_NAME = _contexts[_conf['current-context']]['cluster']

--- a/gitops_server/app_definitions.py
+++ b/gitops_server/app_definitions.py
@@ -3,7 +3,7 @@ import os
 from .namespace import Namespace
 
 
-class Cluster:
+class AppDefinitions:
     def __init__(self, name):
         self.name = name
 

--- a/gitops_server/deploy.py
+++ b/gitops_server/deploy.py
@@ -3,58 +3,57 @@ import logging
 import os
 import tempfile
 
-from .cluster import Cluster
+from . import CLUSTER_NAME
+from .app_definitions import AppDefinitions
 from .git import temp_repo
 from .slack import post
-from .utils import run
+from .utils import get_repo_name_from_url, run
 
 BASE_REPO_DIR = '/var/gitops/repos'
 
 logger = logging.getLogger('gitops')
 
 
-async def post_app_updates(cluster, apps, namespaces, username=None):
+async def post_app_updates(source, apps, namespaces, username=None):
     user_string = f' by {username}' if username else ''
     app_list = '\n'.join(f'\t• `{a}`' for a in apps if not namespaces[a].is_inactive())
     await post(
-        f'A deployment on the `{cluster}` cluster has been initiated{user_string}'
+        f'A deployment from `{source}` has been initiated{user_string} for cluster `{CLUSTER_NAME}`'
         f', the following apps will be updated:\n{app_list}'
     )
 
 
-async def post_app_result(cluster, result):
+async def post_app_result(source, result):
     if result['exit_code'] != 0:
         await post(
-            f'Failed to deploy app `{result["app"]}` to cluster `{cluster}`:\n>>>{result["output"]}'
+            f'Failed to deploy app `{result["app"]}` from `{source}` for cluster `{CLUSTER_NAME}`:'
+            f'\n>>>{result["output"]}'
         )
 
 
-async def post_app_summary(cluster, results):
+async def post_app_summary(source, results):
     n_success = sum([r['exit_code'] == 0 for r in results.values()])
     n_failed = sum([r['exit_code'] != 0 for r in results.values()])
     await post(
-        f'Deployment to `{cluster}` results summary:\n'
+        f'Deployment from `{source}` for `{CLUSTER_NAME}` results summary:\n'
         f'\t• {n_success} succeeded\n'
         f'\t• {n_failed} failed'
     )
 
 
 class Deployer:
-    def __init__(self):
-        pass
-
     async def from_push_event(self, push_event):
         url = push_event['repository']['clone_url']
         self.pusher = push_event['pusher']['name']
         logger.info(f'Initialising deployer for "{url}".')
         before = push_event['before']
         after = push_event['after']
-        self.current_cluster = await self.load_cluster(url, after)
+        self.current_app_definitions = await self.load_app_definitions(url, after)
         try:
-            self.previous_cluster = await self.load_cluster(url, before)
+            self.previous_app_definitions = await self.load_app_definitions(url, before)
         except Exception:
-            logger.warning('An exception was generated loading previous cluster state.')
-            self.previous_cluster = None
+            logger.warning('An exception was generated loading previous app definitions state.')
+            self.previous_app_definitions = None
 
     async def deploy(self):
         changed = self.calculate_changed()
@@ -65,9 +64,12 @@ class Deployer:
         await self.post_init_summary(changed)
         results = {}
         for name in changed:
-            ns = self.current_cluster.namespaces[name]
+            ns = self.current_app_definitions.namespaces[name]
             # If the namespace has been marked inactive, skip.
             if ns.is_inactive():
+                continue
+            # If the namespace isn't targeting our cluster, skip.
+            if ns.target_cluster != self.current_app_definitions.name:
                 continue
             result = await self.deploy_namespace(ns)
             result['app'] = name
@@ -107,7 +109,7 @@ class Deployer:
                     ), catch=True)
                     # TODO: explain
                     if 'has no deployed releases' in results['output']:
-                        logger.info(f'Purging release.')
+                        logger.info('Purging release.')
                         await run((
                             'helm delete'
                             ' --purge'
@@ -122,8 +124,8 @@ class Deployer:
 
     def calculate_changed(self):
         changed = set()
-        for name, namespace in self.current_cluster.namespaces.items():
-            old_namespace = self.previous_cluster.namespaces.get(name) if self.previous_cluster else None
+        for name, namespace in self.current_app_definitions.namespaces.items():
+            old_namespace = self.previous_app_definitions.namespaces.get(name) if self.previous_app_definitions else None
             if old_namespace:
                 if namespace != old_namespace:
                     changed.add(name)
@@ -131,22 +133,18 @@ class Deployer:
                 changed.add(name)
         return changed
 
-    async def load_cluster(self, url, sha):
-        logger.info(f'Loading cluster at "{sha}".')
-        async with temp_repo(url, 'cluster', sha=sha) as repo:
-            cluster = Cluster(self.get_name_from_url(url))
-            cluster.from_path(repo)
-            return cluster
-
-    def get_name_from_url(self, url):
-        # https://github.com/user/repo-name.git > repo-name
-        return url.split('/')[-1].split('.')[0]
+    async def load_app_definitions(self, url, sha):
+        logger.info(f'Loading app definitions at "{sha}".')
+        async with temp_repo(url, 'app_definitions', sha=sha) as repo:
+            app_definitions = AppDefinitions(get_repo_name_from_url(url))
+            app_definitions.from_path(repo)
+            return app_definitions
 
     async def post_init_summary(self, changed):
-        await post_app_updates(self.current_cluster.name, changed, self.current_cluster.namespaces, self.pusher)
+        await post_app_updates(self.current_app_definitions.name, changed, self.current_app_definitions.namespaces, self.pusher)
 
     async def post_deploy_result(self, result):
-        await post_app_result(self.current_cluster.name, result)
+        await post_app_result(self.current_app_definitions.name, result)
 
     async def post_final_summary(self, results):
-        await post_app_summary(self.current_cluster.name, results)
+        await post_app_summary(self.current_app_definitions.name, results)

--- a/gitops_server/deploy.py
+++ b/gitops_server/deploy.py
@@ -69,7 +69,7 @@ class Deployer:
             if ns.is_inactive():
                 continue
             # If the namespace isn't targeting our cluster, skip.
-            if ns.target_cluster != self.current_app_definitions.name:
+            if ns.get_target_cluster() != CLUSTER_NAME:
                 continue
             result = await self.deploy_namespace(ns)
             result['app'] = name

--- a/gitops_server/namespace.py
+++ b/gitops_server/namespace.py
@@ -32,6 +32,9 @@ class Namespace:
     def is_inactive(self):
         return 'inactive' in self.values.get('tags', [])
 
+    def get_target_cluster(self):
+        return self.values.get('cluster')
+
     def make_values(self):
         self.values = {
             **self.deployments,

--- a/gitops_server/utils.py
+++ b/gitops_server/utils.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import yaml
 from functools import partial
+from pathlib import Path
 
 logger = logging.getLogger('gitops')
 
@@ -91,6 +92,21 @@ def split_path(path):
     raise ValueError(f'Invalid application path: {path}')
 
 
-def get_repo_name_from_url(self, url):
+def get_repo_name_from_url(url):
     # https://github.com/user/repo-name.git > repo-name
     return url.split('/')[-1].split('.')[0]
+
+
+def get_cluster_name():
+    fname = os.getenv('KUBE_CONFIG_FILE')
+    if 'HOME' in fname:
+        home = str(Path.home())
+        fname = fname.replace('${HOME}', home)
+    try:
+        with open(fname, 'r') as f:
+            conf = yaml.load(f)
+    except FileNotFoundError:
+        return 'UNKNOWN'
+
+    contexts = {c['name']: c['context'] for c in conf['contexts']}
+    return contexts[conf['current-context']]['cluster']

--- a/gitops_server/utils.py
+++ b/gitops_server/utils.py
@@ -89,3 +89,8 @@ def split_path(path):
         name = parts[2]
         return namespace, name
     raise ValueError(f'Invalid application path: {path}')
+
+
+def get_repo_name_from_url(self, url):
+    # https://github.com/user/repo-name.git > repo-name
+    return url.split('/')[-1].split('.')[0]

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,7 @@
 import os
 from base64 import b64encode
 from invoke import run, task
+
 from dotenv import load_dotenv
 
 IMAGE_URI = '305686791668.dkr.ecr.ap-southeast-2.amazonaws.com/gitops:{tag}'
@@ -12,10 +13,10 @@ def test(ctx, pty=True):
 
 
 @task
-def redeploy(ctx):
+def redeploy(ctx, kubeconfig=''):
     build(ctx)
     push(ctx)
-    deploy(ctx)
+    deploy(ctx, kubeconfig=kubeconfig)
 
 
 @task
@@ -43,7 +44,7 @@ def push(ctx):
 
 
 @task
-def deploy(ctx):
+def deploy(ctx, kubeconfig=''):
     load_dotenv('secrets.env')
     run((
         'helm upgrade'
@@ -59,7 +60,7 @@ def deploy(ctx):
         f" --set secrets.GITHUB_OAUTH_TOKEN={get_secret('GITHUB_OAUTH_TOKEN')}"
         f" --set secrets.GITHUB_WEBHOOK_KEY={get_secret('GITHUB_WEBHOOK_KEY')}"
         f" --set secrets.GIT_CRYPT_KEY={get_secret_file('GIT_CRYPT_KEY_FILE')}"
-        f" --set secrets.KUBE_CONFIG={get_secret_file('KUBE_CONFIG_FILE')}"
+        f" --set secrets.KUBE_CONFIG={kubeconfig or get_secret_file('KUBE_CONFIG_FILE')}"
     ))
 
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -3,7 +3,7 @@ from asynctest.mock import patch
 from gitops_server.deploy import Deployer
 
 from .sample_data import SAMPLE_GITHUB_PAYLOAD
-from .utils import mock_load_cluster
+from .utils import mock_load_app_definitions
 
 # Patch gitops_server.git.run & check correct commands + order
 # Patch command that reads yaml from cluster repo +
@@ -13,7 +13,7 @@ from .utils import mock_load_cluster
 class DeployTests(TestCase):
     @patch('gitops_server.deploy.run')
     @patch('gitops_server.deploy.post')
-    @patch('gitops_server.deploy.Deployer.load_cluster', mock_load_cluster)
+    @patch('gitops_server.deploy.Deployer.load_app_definitions', mock_load_app_definitions)
     @patch('gitops_server.deploy.temp_repo')
     async def test_deployer(self, temp_repo_mock, post_mock, run_mock):
         """Fake a deploy to two servers, bumping fg from 2 to 4."""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -25,7 +25,7 @@ def create_test_yaml(fg=4, bg=2):
         'namespace': 'mynamespace',
         'tags': ['tag1', 'tag2'],
         'image-tag': 'myimagetag',
-        'target-cluster': 'UNKNOWN',
+        'cluster': 'UNKNOWN',
         'containers': {'fg': {'replicas': fg}, 'bg': {'replicas': bg}},
         'environment': {
             'DJANGO_SETTINGS_MODULE': 'my.settings.module',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,21 +1,21 @@
 import yaml
 
-from gitops_server.cluster import Cluster
+from gitops_server.app_definitions import AppDefinitions
 from gitops_server.namespace import Namespace
 
 
-async def mock_load_cluster(self, url, sha):
-    # Set different fg amounts for different sha's to mock a change to cluster
+async def mock_load_app_definitions(self, url, sha):
+    # Set different fg amounts for different sha's to mock a change to app_definitions
     if sha == 'bef04e58a0001234567890123456789012345678':
         fg = 4
     else:
         fg = 2
-    cluster = Cluster('mock-repo')
-    cluster.namespaces = {
+    app_definitions = AppDefinitions('mock-repo')
+    app_definitions.namespaces = {
         'sample-app-1': Namespace('sample-ns-1', path=create_test_yaml(fg=fg)),
         'sample-app-2': Namespace('sample-ns-2', path=create_test_yaml(fg=fg)),
     }
-    return cluster
+    return app_definitions
 
 
 def create_test_yaml(fg=4, bg=2):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -25,6 +25,7 @@ def create_test_yaml(fg=4, bg=2):
         'namespace': 'mynamespace',
         'tags': ['tag1', 'tag2'],
         'image-tag': 'myimagetag',
+        'target-cluster': 'UNKNOWN',
         'containers': {'fg': {'replicas': fg}, 'bg': {'replicas': bg}},
         'environment': {
             'DJANGO_SETTINGS_MODULE': 'my.settings.module',
@@ -46,3 +47,39 @@ def create_test_yaml(fg=4, bg=2):
     with open('/tmp/secrets.yml', 'w+') as fh:
         fh.write(yaml.dump(data))
     return '/tmp/'
+
+
+# def create_test_kubeconfig():
+#     data = {
+#         'apiVersion': 'v1',
+#         'clusters': [
+#             {
+#                 'cluster': {
+#                     'certificate-authority-data': 'XXX',
+#                     'server': 'https://XXX.elb.amazonaws.com',
+#                 },
+#                 'name': 'testcluster',
+#             },
+#         ],
+#         'contexts': [
+#             {
+#                 'context': {
+#                     'cluster': 'testcluster',
+#                     'user': 'testuser',
+#                 },
+#                 'name': 'testcontext',
+#             },
+#         ],
+#         'current-context': 'testcontext',
+#         'kind': 'Config',
+#         'preferences': {},
+#         'users': [
+#             {
+#                 'name': 'testuser',
+#                 'user': {},
+#             },
+#         ],
+#     }
+#     with open('/tmp/kubeconfig', 'w+') as fh:
+#         fh.write(yaml.dump(data))
+#     return '/tmp/'


### PR DESCRIPTION
Added support for running multiple clusters, with the expectation there'll be one gitops instance running on each.

- Renamed 'Cluster' to 'AppDefinitions' (a bit wordy, but hopefully more descriptive, and disambiaguates from actual kube cluster). Alternative name could've also been `ClusterRepo`, but I felt that still had some ambiguity to it.. ;/
- kubeconfig file path can now be passed to invoke commands, to deploy gitops server to other clusters easily.
- Made gitops bail out if it the app it's looking at isn't targeting the cluster it's running on.