### PR TITLE
Attach tests as a volume, not using COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ RUN    apk add --no-cache --update --virtual build-dependencies \
     && rm -rf /var/lib/apt/lists/* /root/.cache
 COPY common /app/common
 COPY gitops_server /app/gitops_server
-COPY tests /app/tests
 
 COPY cluster.key /app
 ENV GIT_CRYPT_KEY_FILE=/app/cluster.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 services:
   web:
     build: .
@@ -7,5 +7,6 @@ services:
     volumes:
       - ./common:/app/common
       - ./gitops_server:/app/gitops_server
+      - ./tests:/app/tests
     env_file:
       - secrets.env


### PR DESCRIPTION
Attaches the `tests` directory using a docker-compose `volumes` directive, instead of `COPY` inside the `Dockerfile`.

This means local changes to the tests files are tracked by the docker instance.