### PR TITLE
Refactor Gitops for types and helm repo deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Secrets should be placed in `secrets.env`. The example file `secrets.example.env
 
 Gitops has a helm chart defining its deployment. Invoke scripts are provided to make deployment painless. See `tasks.py`.
 
+Add `export GITOPS_APPS_DIRECTORY=~/<cluster-apps-folder>` to invoke gitops from any directory.
+
 ## Roadmap
 
  * Handle failure on initial application deployment.

--- a/common/app.py
+++ b/common/app.py
@@ -1,7 +1,7 @@
 import json
 import os
 from base64 import b64encode
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from .utils import load_yaml
 
@@ -67,6 +67,25 @@ class App:
             )
         else:
             return deployment_config.get('image')
+
+    @property
+    def image(self) -> str:
+        return self.values.get('image', "")
+
+    @property
+    def image_tag(self) -> str:
+        """ """
+        return self.image.split(':')[-1]
+
+    @property
+    def cluster(self) -> str:
+        """ """
+        return self.values.get('cluster')
+
+    @property
+    def tags(self) -> List[str]:
+        """ """
+        return self.values.get('tags', [])
 
 
 class Chart:

--- a/common/app.py
+++ b/common/app.py
@@ -1,7 +1,7 @@
 import json
 import os
 from base64 import b64encode
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from .utils import load_yaml
 
@@ -14,14 +14,7 @@ DEPLOYMENT_ATTRIBUTES = [
 
 
 class App:
-    def __init__(self,
-        name: str,
-        path: Optional[str] = None,
-        deployments: Optional[Dict] = None,
-        secrets: Optional[Dict] = None,
-        load_secrets: bool = True,
-        account_id: str = ''
-    ):
+    def __init__(self, name: str, path: Optional[str] = None, deployments: Optional[Dict] = None, secrets: Optional[Dict] = None, load_secrets: bool = True, account_id: str = ''):
         self.name = name
         self.path = path
         self.account_id = account_id
@@ -34,6 +27,7 @@ class App:
             else:
                 self.secrets = secrets or {}
         self.values = self._make_values()
+        self.chart = Chart(self.values['chart'])
 
     def __eq__(self, other):
         return (
@@ -73,3 +67,54 @@ class App:
             )
         else:
             return deployment_config.get('image')
+
+
+class Chart:
+    """Represents a Helm chart
+
+    Can be stored in a git repo, helm repo or local path
+
+    Example definition in `deployments.yml`:
+    chart:
+      type: git
+      git_sha: develop
+      git_repo_url: https://github.com/uptick/workforce
+
+    of
+    chart:
+      type: helm
+      helm_repo: brigade
+      helm_repo_url: https://brigadecore.github.io/charts
+      helm_chart: brigade/brigade
+
+    If a dictionary is not passed, it is assumed to be a git repo. eg:
+      chart: https://github.com/uptick/workforce
+    """
+    def __init__(self, definition: Union[Dict, str]):
+        if isinstance(definition, str):
+            # for backwards compat, any chart definition which is a string, is a git repo
+            self.type = "git"
+            self.git_sha = None
+            self.git_repo_url = definition
+        elif isinstance(definition, dict):
+            self.type = definition['type']
+            self.git_sha = definition.get('git_sha')
+            self.git_repo_url = definition.get('git_repo_url')
+            self.helm_repo = definition.get('helm_repo')
+            self.helm_repo_url = definition.get('helm_repo_url')
+            self.helm_chart = definition.get('helm_chart')
+            self.path = definition.get('path')
+        else:
+            raise Exception("Chart definition must be either a dict or string. Instead it is: {definition}")
+
+        if self.git_repo_url and '@' in self.git_repo_url:
+            self.git_repo_url, self.git_sha = self.git_repo_url.split('@')
+
+    def is_git(self):
+        return self.type == "git"
+
+    def is_helm(self):
+        return self.type == "helm"
+
+    def is_local(self):
+        return self.type == "local"

--- a/gitops/db.py
+++ b/gitops/db.py
@@ -19,7 +19,7 @@ def backup(ctx, app_name):
         'app': app_name
     }
     app = get_app_details(app_name, load_secrets=False)
-    asyncio.run(kube._run_job('jobs/backup-job.yml', values, context=app['cluster'], namespace='workforce', sequential=True))
+    asyncio.run(kube._run_job('jobs/backup-job.yml', values, context=app.cluster, namespace='workforce', sequential=True))
 
 
 @task
@@ -39,7 +39,7 @@ def restore_backup(ctx, app_name, index, cleanup=True):
         'app': app_name,
     }
     app = get_app_details(app_name, load_secrets=False)
-    asyncio.run(kube._run_job('jobs/restore-job.yml', values, context=app['cluster'], namespace='workforce', cleanup=cleanup))
+    asyncio.run(kube._run_job('jobs/restore-job.yml', values, context=app.cluster, namespace='workforce', cleanup=cleanup))
 
 
 @task
@@ -47,8 +47,8 @@ def copy_db(ctx, source, destination, skip_backup=False, cleanup=True):
     """ Copy database between apps. """
     source_app = get_app_details(source, load_secrets=False)
     destination_app = get_app_details(destination, load_secrets=False)
-    if source_app['cluster'] != destination_app['cluster']:
-        print(warning(f"Source ({source!r} on {source_app['cluster']!r}) and destination ({destination!r} on {destination_app['cluster']!r}) apps must belong to the same cluster."))
+    if source_app.cluster != destination_app.cluster:
+        print(warning(f"Source ({source!r} on {source_app.cluster!r}) and destination ({destination!r} on {destination_app.cluster!r}) apps must belong to the same cluster."))
         return
     kube.confirm_database(destination)
     values = {
@@ -57,7 +57,7 @@ def copy_db(ctx, source, destination, skip_backup=False, cleanup=True):
         'destination': destination,
         'skip_backup': 'skip' if skip_backup else ''
     }
-    asyncio.run(kube._run_job('jobs/copy-db-job.yml', values, context=source_app['cluster'], namespace='workforce', cleanup=cleanup))
+    asyncio.run(kube._run_job('jobs/copy-db-job.yml', values, context=source_app.cluster, namespace='workforce', cleanup=cleanup))
     print(progress('You may want to clear the redis cache now!'))
     print(progress(f'\t- gitops mcommand {destination} clear_cache'))
 

--- a/gitops/utils/apps.py
+++ b/gitops/utils/apps.py
@@ -69,7 +69,6 @@ def get_apps(filter=[], exclude=[], mode='PROMPT', autoexclude_inactive=True, me
     apps = []
     existing_tags = set()
     try:
-        print(APPS_PATH)
         directory = sorted(APPS_PATH.iterdir())
     except FileNotFoundError:
         raise AppDoesNotExist()

--- a/gitops/utils/apps.py
+++ b/gitops/utils/apps.py
@@ -2,6 +2,7 @@ import os
 from colorama import Fore
 from pathlib import Path
 from tabulate import tabulate
+from typing import List
 
 from common.app import DEPLOYMENT_ATTRIBUTES, App
 
@@ -13,11 +14,13 @@ from .exceptions import AppDoesNotExist, AppOperationAborted
 from .images import colour_image
 from .tags import colour_tags, validate_tags
 
+APPS_PATH = Path(os.environ.get('GITOPS_APPS_DIRECTORY', 'apps'))
 
-def get_app_details(app_name, load_secrets=True):
+
+def get_app_details(app_name: str, load_secrets: bool = True) -> App:
     account_id = get_account_id() if load_secrets else 'UNKNOWN'
     try:
-        app = App(app_name, path=f'apps/{app_name}', load_secrets=load_secrets, account_id=account_id)
+        app = App(app_name, path=APPS_PATH / app_name, load_secrets=load_secrets, account_id=account_id)
     except FileNotFoundError:
         # Check if apps dir doesn't exist, or just that one app
         if os.path.exists("apps"):
@@ -25,13 +28,11 @@ def get_app_details(app_name, load_secrets=True):
         else:
             raise AppDoesNotExist()
 
-    values = app.values
-    values['name'] = app_name
-    return values
+    return app
 
 
 def update_app(app_name, **kwargs):
-    filename = Path('apps') / app_name / 'deployment.yml'
+    filename = APPS_PATH / app_name / 'deployment.yml'
     with open(filename, 'r') as f:
         data = yaml.safe_load(f)
     for k, v in kwargs.items():
@@ -68,7 +69,8 @@ def get_apps(filter=[], exclude=[], mode='PROMPT', autoexclude_inactive=True, me
     apps = []
     existing_tags = set()
     try:
-        directory = sorted(Path('apps').iterdir())
+        print(APPS_PATH)
+        directory = sorted(APPS_PATH.iterdir())
     except FileNotFoundError:
         raise AppDoesNotExist()
     for entry in directory:
@@ -77,15 +79,13 @@ def get_apps(filter=[], exclude=[], mode='PROMPT', autoexclude_inactive=True, me
         app = get_app_details(entry.name, load_secrets=load_secrets)
 
         pseudotags = [
-            app['name'],
-            app['cluster'],
+            app.name,
+            app.cluster
         ]
+        if app.image:
+            pseudotags.append(app.image.split('-')[0])
 
-        image = app['image'].split(':')[-1].split('-')[0] if app.get('image', '') else None
-        if image:
-            pseudotags.append(image)
-
-        tags = set(app['tags'] + pseudotags)
+        tags = set(app.tags + pseudotags)
         existing_tags |= tags
         if filter <= tags and not exclude & tags:
             apps.append(app)
@@ -106,7 +106,7 @@ def get_apps(filter=[], exclude=[], mode='PROMPT', autoexclude_inactive=True, me
     return apps
 
 
-def preview_apps(apps):
+def preview_apps(apps: List[App]):
     """ Produce a summary of apps, their tags, and their expected images & replicas.
         May not necessarily reflect actual app statuses if recent changes haven't yet been pushed to
         the remote, or the deployment has failed.
@@ -114,12 +114,12 @@ def preview_apps(apps):
     table = []
     for app in apps:
         table.append([
-            colourise(app['name'], Fore.RED, lambda _: 'inactive' in app['tags']),
-            colour_image(app['image'].split(':')[-1]),
-            app['cluster'],
-            colourise(app.get('containers', {}).get('fg', {}).get('replicas', '-'), Fore.LIGHTBLACK_EX, lambda r: r == '-'),
-            colourise(app.get('containers', {}).get('bg', {}).get('replicas', '-'), Fore.LIGHTBLACK_EX, lambda r: r == '-'),
-            colour_tags(app['tags']),
+            colourise(app.name, Fore.RED, lambda _: 'inactive' in app.tags),
+            colour_image(app.image_tag),
+            app.cluster,
+            colourise(app.values.get('containers', {}).get('fg', {}).get('replicas', '-'), Fore.LIGHTBLACK_EX, lambda r: r == '-'),
+            colourise(app.values.get('containers', {}).get('bg', {}).get('replicas', '-'), Fore.LIGHTBLACK_EX, lambda r: r == '-'),
+            colour_tags(app.tags),
         ])
     # Sort table by app tags. TODO: Do we want this over alphabetical app sorting..?
     # table = sorted(table, key=lambda x: x[4])

--- a/gitops/utils/apps.py
+++ b/gitops/utils/apps.py
@@ -75,11 +75,16 @@ def get_apps(filter=[], exclude=[], mode='PROMPT', autoexclude_inactive=True, me
         if not entry.is_dir():
             continue
         app = get_app_details(entry.name, load_secrets=load_secrets)
+
         pseudotags = [
             app['name'],
-            app['image'].split(':')[-1].split('-')[0],
             app['cluster'],
         ]
+
+        image = app['image'].split(':')[-1].split('-')[0] if app.get('image', '') else None
+        if image:
+            pseudotags.append(image)
+
         tags = set(app['tags'] + pseudotags)
         existing_tags |= tags
         if filter <= tags and not exclude & tags:

--- a/gitops/utils/images.py
+++ b/gitops/utils/images.py
@@ -56,7 +56,10 @@ def get_latest_image(prefix):
     return latest_image_tag
 
 
-def colour_image(image_tag):
+def colour_image(image_tag: str):
+    if not image_tag:
+        return image_tag
+
     bits = image_tag.split('-')
     bits[0] = colourise(bits[0], color_hash(bits[1]))
     return '-'.join(bits)

--- a/gitops/utils/kube.py
+++ b/gitops/utils/kube.py
@@ -19,21 +19,23 @@ from invoke.exceptions import UnexpectedExit
 import boto3
 import humanize
 
+from common.app import App
+
+from gitops.utils.apps import APPS_PATH
 from gitops.utils.async_runner import async_run
 
 from .exceptions import CommandError
 
 
-async def run_job(app, command, cleanup=True, sequential=True):
+async def run_job(app: App, command, cleanup=True, sequential=True):
     job_id = make_key(4).lower()
-    app_name = app['name']
     values = {
-        'name': f'{app_name}-command-{job_id}',
-        'app': app_name,
+        'name': f'{app.name}-command-{job_id}',
+        'app': app.name,
         'command': str(shlex.split(command)),
-        'image': app['image'],
+        'image': app.image,
     }
-    return await _run_job('jobs/command-job.yml', values, context=app['cluster'], namespace='workforce', attach=True, cleanup=cleanup, sequential=sequential)
+    return await _run_job('jobs/command-job.yml', values, context=app.cluster, namespace='workforce', attach=True, cleanup=cleanup, sequential=sequential)
 
 
 def list_backups(product, prefix):
@@ -183,7 +185,7 @@ async def _run_job(path, values={}, context='', namespace='default', attach=Fals
     name = values['name']
     logs = ''
     with tempfile.NamedTemporaryFile('wt', suffix='.yml') as tmp:
-        resource = open(path, 'r').read()
+        resource = open(APPS_PATH / ".." / path, 'r').read()
         for k, v in values.items():
             resource = resource.replace('{{ %s }}' % k, v)
         tmp.write(resource)

--- a/gitops_server/deploy.py
+++ b/gitops_server/deploy.py
@@ -3,6 +3,8 @@ import logging
 import os
 import tempfile
 
+from common.app import App
+
 from . import ACCOUNT_ID, CLUSTER_NAME
 from .app_definitions import AppDefinitions
 from .git import temp_repo
@@ -50,9 +52,9 @@ class Deployer:
         logger.info(f'Initialising deployer for "{url}".')
         before = push_event['before']
         after = push_event['after']
-        self.current_app_definitions = await self.load_app_definitions(url, after)
+        self.current_app_definitions = await self.load_app_definitions(url, sha=after)
         # TODO: Handle case where there is no previous commit.
-        self.previous_app_definitions = await self.load_app_definitions(url, before)
+        self.previous_app_definitions = await self.load_app_definitions(url, sha=before)
 
     async def deploy(self):
         added_apps, updated_apps, removed_apps = self.calculate_app_deltas()
@@ -72,35 +74,51 @@ class Deployer:
             await post_result(self.current_app_definitions.name, result)
         for app_name in removed_apps:
             app = self.previous_app_definitions.apps[app_name]
-            result = await self.update_app_deployment(app, uninstall=True)
+            result = await self.uninstall_app(app)
             result['app'] = app_name
             results[app_name] = result
             await post_result(self.current_app_definitions.name, result)
         await post_result_summary(self.current_app_definitions.name, results)
 
-    async def update_app_deployment(self, app, uninstall=False):
-        if uninstall:
-            logger.info(f'Uninstalling app {app.name!r}.')
-            return await run(f"helm uninstall {app.name} -n {app.values['namespace']}", catch=True)
+    async def uninstall_app(self, app: App):
+        logger.info(f'Uninstalling app {app.name!r}.')
+        return await run(f"helm uninstall {app.name} -n {app.values['namespace']}", catch=True)
 
+    async def update_app_deployment(self, app: App):
         logger.info(f'Deploying app {app.name!r}.')
-        repo, sha = app.values['chart'], None
-        if '@' in repo:
-            repo, sha = repo.split('@')
-        async with temp_repo(repo, 'chart', sha=sha) as repo:
-            await run(f'cd {repo}; helm dependency build')
+
+        if app.chart.is_git():
+            async with temp_repo(app.chart.git_repo_url, sha=app.chart.git_sha) as chart_folder_path:
+                await run(f'cd {chart_folder_path}; helm dependency build')
+                with tempfile.NamedTemporaryFile(suffix='.yml') as cfg:
+                    cfg.write(json.dumps(app.values).encode())
+                    cfg.flush()
+                    os.fsync(cfg.fileno())
+                    return await run((
+                        'helm upgrade'
+                        ' --install'
+                        f' -f {cfg.name}'
+                        f" --namespace={app.values['namespace']}"
+                        f' {app.name}'
+                        f' {chart_folder_path}'
+                    ), catch=True)
+        elif app.chart.is_helm():
             with tempfile.NamedTemporaryFile(suffix='.yml') as cfg:
                 cfg.write(json.dumps(app.values).encode())
                 cfg.flush()
                 os.fsync(cfg.fileno())
+                await run(f'helm repo add {app.chart.helm_repo} {app.chart.helm_repo_url}')
                 return await run((
                     'helm upgrade'
                     ' --install'
                     f' -f {cfg.name}'
                     f" --namespace={app.values['namespace']}"
                     f' {app.name}'
-                    f' {repo}'
+                    f' {app.chart.helm_chart}'
                 ), catch=True)
+        else:
+            logger.warning("Local is not implemented yet")
+            return
 
     def calculate_app_deltas(self):
         cur = self.current_app_definitions.apps.keys()
@@ -121,9 +139,9 @@ class Deployer:
                 updated.add(app_name)
         return added, updated, removed
 
-    async def load_app_definitions(self, url, sha):
+    async def load_app_definitions(self, url: str, sha: str):
         logger.info(f'Loading app definitions at "{sha}".')
-        async with temp_repo(url, 'app_definitions', sha=sha) as repo:
+        async with temp_repo(url, sha=sha) as repo:
             app_definitions = AppDefinitions(get_repo_name_from_url(url))
             app_definitions.from_path(repo)
             return app_definitions

--- a/gitops_server/deploy.py
+++ b/gitops_server/deploy.py
@@ -87,7 +87,7 @@ class Deployer:
     async def update_app_deployment(self, app: App):
         logger.info(f'Deploying app {app.name!r}.')
 
-        if app.chart.is_git():
+        if app.chart.type == "git":
             async with temp_repo(app.chart.git_repo_url, sha=app.chart.git_sha) as chart_folder_path:
                 await run(f'cd {chart_folder_path}; helm dependency build')
                 with tempfile.NamedTemporaryFile(suffix='.yml') as cfg:
@@ -102,7 +102,7 @@ class Deployer:
                         f' {app.name}'
                         f' {chart_folder_path}'
                     ), catch=True)
-        elif app.chart.is_helm():
+        elif app.chart.type == "helm":
             with tempfile.NamedTemporaryFile(suffix='.yml') as cfg:
                 cfg.write(json.dumps(app.values).encode())
                 cfg.flush()

--- a/gitops_server/git.py
+++ b/gitops_server/git.py
@@ -2,6 +2,7 @@ import logging
 import os
 import tempfile
 from contextlib import asynccontextmanager
+from typing import Optional
 
 from .utils import run
 
@@ -10,52 +11,21 @@ BASE_REPO_DIR = '/var/gitops/repos'
 logger = logging.getLogger('gitops')
 
 
-def get_repo_path(name):
-    path = os.path.join(BASE_REPO_DIR, name)
-    os.makedirs(path, exist_ok=True)
-    return path
+async def clone_repo(git_repo_url: str, path: str, sha: Optional[str] = None):
+    """Shallow Clones a git repo url to path and git-crypt unlocks all encrypted files"""
+    logger.info(f'Cloning "{git_repo_url}".')
 
+    url_with_oauth_token = git_repo_url.replace("://", f"://{os.environ['GITHUB_OAUTH_TOKEN'].strip()}@")
 
-def inject_oauth_token(url):
-    ii = url.index('://') + 3
-    return url[:ii] + os.environ['GITHUB_OAUTH_TOKEN'] + '@' + url[ii:]
+    await run(f'git clone {url_with_oauth_token} {path}; cd path; git checkout {sha}')
 
-
-async def clone_repo(name, url, path):
-    # TODO: Don't log the oauth token.
-    url = inject_oauth_token(url)
-    logger.info(f'Cloning "{name}" from "{url}".')
-    await run(f'git clone {url} {path}')
     await run(f'cd {path}; git-crypt unlock {os.environ["GIT_CRYPT_KEY_FILE"]}')
 
 
-async def update_repo(name, url, path):
-    logger.info('PULL: {name}')
-    await run(f'cd {path}; git pull {url}')
-
-
-async def checkout_repo_sha(name, sha, path):
-    logger.info(f'Checkout "{name}" at "{sha}".')
-    await run(f'cd {path}; git checkout {sha}')
-
-
-async def refresh_repo(name, url, sha=None, path=None):
-    if not path:
-        path = get_repo_path(name)
-    if not os.path.exists(path):
-        await update_repo(name, url, path)
-    else:
-        await clone_repo(name, url, path)
-    if sha:
-        await checkout_repo_sha(name, sha, path)
-
-
 @asynccontextmanager
-async def temp_repo(url, name=None, sha=None):
-    if not name:
-        name = 'anonymous'
+async def temp_repo(git_repo_url: str, sha: Optional[str] = None) -> str:
+    """Checks out a git_repo_url to a temporary folder location. Returns temporary folder location"""
     with tempfile.TemporaryDirectory() as tmp:
-        if not isinstance(tmp, str):
-            tmp = tmp.name
-        await refresh_repo(name, url, sha=sha, path=tmp)
-        yield tmp
+        temporary_folder_path = tmp.name
+        await clone_repo(git_repo_url, path=temporary_folder_path, sha=sha)
+        yield temporary_folder_path

--- a/gitops_server/utils.py
+++ b/gitops_server/utils.py
@@ -33,7 +33,7 @@ def sync_run(command, catch=False):
         )
     except subprocess.CalledProcessError as e:
         if not catch:
-            raise
+            raise e
         exit_code = e.returncode
         output = e.output
     return {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -50,7 +50,6 @@ class TestChart(TestCase):
         self.assertEqual(chart.type, 'git')
         self.assertEqual(chart.git_repo_url, 'https://github.com/uptick/workforce')
         self.assertIsNone(chart.git_sha)
-        self.assertTrue(chart.is_git())
 
     def test_git_repo_url_sha_is_parsed_properly(self):
         chart = Chart('https://github.com/uptick/workforce@123')
@@ -58,7 +57,6 @@ class TestChart(TestCase):
         self.assertEqual(chart.type, 'git')
         self.assertEqual(chart.git_repo_url, 'https://github.com/uptick/workforce')
         self.assertEqual(chart.git_sha, '123')
-        self.assertTrue(chart.is_git())
 
     def test_git_repo_config_is_parsed_properly(self):
         chart = Chart({
@@ -69,7 +67,6 @@ class TestChart(TestCase):
         self.assertEqual(chart.type, 'git')
         self.assertEqual(chart.git_repo_url, 'https://github.com/uptick/workforce')
         self.assertEqual(chart.git_sha, '123')
-        self.assertTrue(chart.is_git())
 
     def test_helm_repo_is_parsed_properly(self):
         chart = Chart({
@@ -80,7 +77,6 @@ class TestChart(TestCase):
         })
 
         self.assertEqual(chart.type, 'helm')
-        self.assertTrue(chart.is_helm())
         self.assertEqual(chart.helm_repo_url, 'https://brigade')
         self.assertEqual(chart.helm_chart, 'brigade/brigade')
 
@@ -91,5 +87,4 @@ class TestChart(TestCase):
         })
 
         self.assertEqual(chart.type, 'local')
-        self.assertTrue(chart.is_local())
         self.assertEqual(chart.path, '.')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,13 +1,13 @@
 from unittest import TestCase
 
-from common.app import App
+from common.app import App, Chart
 
 from .utils import create_test_yaml
 
 
 class MakeImageTests(TestCase):
     def test_direct_image(self):
-        app = App('test', deployments={'image': 'I0'})
+        app = App('test', deployments={'image': 'I0', 'chart': 'https://github.com/uptick/workforce'})
         self.assertEqual(app.values['image'], 'I0')
 
     def test_image_tag(self):
@@ -17,6 +17,7 @@ class MakeImageTests(TestCase):
                 'images': {
                     'template': 'image-template-{tag}'
                 },
+                'chart': 'https://uptick.com/uptick/workforce',
                 'image-tag': 'I0'
             }
         )
@@ -25,6 +26,9 @@ class MakeImageTests(TestCase):
     def test_no_image_tag_is_valid(self):
         app = App(
             'test',
+            deployments={
+                'chart': 'https://uptick.com/uptick/workforce',
+            }
         )
         self.assertIsNone(app.values.get('image'))
 
@@ -37,3 +41,55 @@ class MakeImageTests(TestCase):
         path = create_test_yaml()
         app = App('test', path)
         self.assertNotIn('images', app.values)
+
+
+class TestChart(TestCase):
+    def test_string_git_chart_is_parsed_properly_as_git(self):
+        chart = Chart('https://github.com/uptick/workforce')
+
+        self.assertEqual(chart.type, 'git')
+        self.assertEqual(chart.git_repo_url, 'https://github.com/uptick/workforce')
+        self.assertIsNone(chart.git_sha)
+        self.assertTrue(chart.is_git())
+
+    def test_git_repo_url_sha_is_parsed_properly(self):
+        chart = Chart('https://github.com/uptick/workforce@123')
+
+        self.assertEqual(chart.type, 'git')
+        self.assertEqual(chart.git_repo_url, 'https://github.com/uptick/workforce')
+        self.assertEqual(chart.git_sha, '123')
+        self.assertTrue(chart.is_git())
+
+    def test_git_repo_config_is_parsed_properly(self):
+        chart = Chart({
+            'type': 'git',
+            'git_repo_url': 'https://github.com/uptick/workforce@123'
+        })
+
+        self.assertEqual(chart.type, 'git')
+        self.assertEqual(chart.git_repo_url, 'https://github.com/uptick/workforce')
+        self.assertEqual(chart.git_sha, '123')
+        self.assertTrue(chart.is_git())
+
+    def test_helm_repo_is_parsed_properly(self):
+        chart = Chart({
+            'type': 'helm',
+            'helm_repo': 'brigade',
+            'helm_repo_url': 'https://brigade',
+            'helm_chart': 'brigade/brigade',
+        })
+
+        self.assertEqual(chart.type, 'helm')
+        self.assertTrue(chart.is_helm())
+        self.assertEqual(chart.helm_repo_url, 'https://brigade')
+        self.assertEqual(chart.helm_chart, 'brigade/brigade')
+
+    def test_local_repo_is_parsed_properly(self):
+        chart = Chart({
+            'type': 'local',
+            'path': '.',
+        })
+
+        self.assertEqual(chart.type, 'local')
+        self.assertTrue(chart.is_local())
+        self.assertEqual(chart.path, '.')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,8 +7,8 @@ from .utils import create_test_yaml
 
 class MakeImageTests(TestCase):
     def test_direct_image(self):
-        app = App('test')
-        self.assertEqual(app.make_image({'image': 'I0'}), 'I0')
+        app = App('test', deployments={'image': 'I0'})
+        self.assertEqual(app.values['image'], 'I0')
 
     def test_image_tag(self):
         app = App(
@@ -16,10 +16,17 @@ class MakeImageTests(TestCase):
             deployments={
                 'images': {
                     'template': 'image-template-{tag}'
-                }
+                },
+                'image-tag': 'I0'
             }
         )
-        self.assertEqual(app.make_image({'image-tag': 'I0'}), 'image-template-I0')
+        self.assertEqual(app.values['image'], 'image-template-I0')
+
+    def test_no_image_tag_is_valid(self):
+        app = App(
+            'test',
+        )
+        self.assertIsNone(app.values.get('image'))
 
     def test_image_tag_from_yaml(self):
         path = create_test_yaml()


### PR DESCRIPTION
- Added python types to disambiguate our usage of `app` and `repo`.
  Where possible, we should be passing around App instead of some untyped dictionary. This will prevent errors in the future as well as provide a consistent interface for validation in the future.
- Added Chart as a configurable object (while keeping the existing chart definition backwards compatible).  Charts are now either a reference to a git repo or a reference to a chart repo.
- Gitops can be invoked from any folder if you set `GITOPS_APPS_DIRECTORY` as an environment variable
