### PR TITLE
DEV-195: Add health check endpoint 

### DIFF
--- a/charts/gitops/Chart.yaml
+++ b/charts/gitops/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: GitOps Server Helm chart.
 name: gitops
-version: 0.8.4
+version: 0.8.7

--- a/charts/gitops/templates/deployment.yml
+++ b/charts/gitops/templates/deployment.yml
@@ -25,6 +25,12 @@ spec:
       containers:
       - name: gitops
         image: {{ .Values.image }}
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 5
         ports:
         - containerPort: 8000
         envFrom:
@@ -68,6 +74,7 @@ spec:
           - key: GIT_CRYPT_KEY
             path: git_crypt_key
       restartPolicy: Always
+
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/gitops/__init__.py
+++ b/gitops/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from .utils.cli import success, warning
 
-__version__ = "0.8.6"
+__version__ = "0.8.7"
 
 
 # Checking gitops version matches cluster repo version.

--- a/gitops_server/main.py
+++ b/gitops_server/main.py
@@ -14,9 +14,21 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("gitops")
 
 
+class EndpointFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.args[2] not in {"/readyz", "/livez", "/"}  # type: ignore
+
+
+# Filter out / from access logs (We don't care about these calls)
+logging.getLogger("uvicorn.access").addFilter(EndpointFilter())
+logger = logging.getLogger("document-wrapper")
+
+
 @app.get("/")
-def index():
-    return {}
+@app.get("/readyz")
+@app.get("/livez")
+def health_check():
+    return {"status": "ok"}
 
 
 @app.post("/webhook")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitops"
-version = "0.8.6"
+version = "0.8.7"
 description = "Manage multiple apps across one or more k8s clusters."
 authors = ["Jarek Głowacki <jarekwg@gmail.com>"]
 license = "BSD"


### PR DESCRIPTION
Gitops recently was frozen and did not restart.

This PR adds a liveness check on `/livez`. The current kubernetes convention is `/livez` for liveness probe and `/readyz` for readiness endpoint.

This PR also bumps up the version to 0.8.7