### PR TITLE
feat: Allow gitops commands to be run against different namespaces.

### DIFF
--- a/charts/gitops/Chart.yaml
+++ b/charts/gitops/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: GitOps Server Helm chart.
 name: gitops
-version: 0.9.6
+version: 0.9.10

--- a/gitops/__init__.py
+++ b/gitops/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from .utils.cli import success, warning
 
-__version__ = "0.9.9"
+__version__ = "0.9.10"
 
 
 # Checking gitops version matches cluster repo version.

--- a/gitops/common/app.py
+++ b/gitops/common/app.py
@@ -28,6 +28,7 @@ class App:
         deployments = deployments or {}
         secrets = secrets or {}
         self.values = self._make_values(deployments, secrets)
+        self.namespace: str = self.values["namespace"]
         self.chart = Chart(self.values["chart"])
 
     def __eq__(self, other):

--- a/gitops/common/app.py
+++ b/gitops/common/app.py
@@ -5,7 +5,15 @@ from typing import Dict, List, Optional, Union
 
 from .utils import load_yaml
 
-DEPLOYMENT_ATTRIBUTES = ["tags", "image-tag", "containers", "environment", "cluster", "bump"]
+DEPLOYMENT_ATTRIBUTES = [
+    "tags",
+    "image-tag",
+    "containers",
+    "environment",
+    "cluster",
+    "bump",
+    "namespace",
+]
 
 
 class App:

--- a/gitops/db.py
+++ b/gitops/db.py
@@ -29,7 +29,7 @@ def backup(ctx, app_name):
             "jobs/backup-job.yml",
             values,
             context=app.cluster,
-            namespace="workforce",
+            namespace=app.namespace,
             sequential=True,
         )
     )
@@ -57,7 +57,7 @@ def restore_backup(ctx, app_name, index, cleanup=True):
             "jobs/restore-job.yml",
             values,
             context=app.cluster,
-            namespace="workforce",
+            namespace=app.namespace,
             cleanup=cleanup,
         )
     )
@@ -82,7 +82,7 @@ def copy_db(ctx, source, destination, skip_backup=False, cleanup=True):
             "jobs/copy-db-job.yml",
             values,
             context=source_app.cluster,
-            namespace="workforce",
+            namespace=source_app.namespace,
             cleanup=cleanup,
         )
     )
@@ -242,7 +242,7 @@ def wipe_db(ctx, destination, skip_backup=False, cleanup=True):
             "jobs/wipe-db-job.yml",
             values,
             context=source_app.cluster,
-            namespace="workforce",
+            namespace=source_app.namespace,
             cleanup=cleanup,
         )
     )

--- a/gitops/utils/kube.py
+++ b/gitops/utils/kube.py
@@ -68,7 +68,7 @@ async def run_job(
         "jobs/command-job.yml",
         values,
         context=app.cluster,
-        namespace="workforce",
+        namespace=app.namespace,
         attach=True,
         cleanup=cleanup,
         sequential=sequential,

--- a/gitops_server/workers/deployer/deploy.py
+++ b/gitops_server/workers/deployer/deploy.py
@@ -147,7 +147,7 @@ class Deployer:
         async with self.semaphore:
             logger.info(f"Uninstalling app {app.name!r}.")
             result = await run(
-                f"helm uninstall {app.name} -n {app.values['namespace']}", suppress_errors=True
+                f"helm uninstall {app.name} -n {app.namespace}", suppress_errors=True
             )
             update_result = UpdateAppResult(app_name=app.name, **result)
             await post_result(
@@ -180,7 +180,7 @@ class Deployer:
                             " --timeout=600s"
                             f"{' --set skip_migrations=true' if self.skip_migrations else ''}"
                             f" -f {cfg.name}"
-                            f" --namespace={app.values['namespace']}"
+                            f" --namespace={app.namespace}"
                             f" {app.name}"
                             f" {chart_folder_path}",
                             suppress_errors=True,
@@ -200,7 +200,7 @@ class Deployer:
                         " --timeout=600s"
                         f"{' --set skip_migrations=true' if self.skip_migrations else ''}"
                         f" -f {cfg.name}"
-                        f" --namespace={app.values['namespace']}"
+                        f" --namespace={app.namespace}"
                         f" {app.name}"
                         f" {app.chart.helm_chart} {chart_version_arguments}",
                         suppress_errors=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitops"
-version = "0.9.8"
+version = "0.9.10"
 description = "Manage multiple apps across one or more k8s clusters."
 authors = ["Jarek Głowacki <jarekwg@gmail.com>"]
 license = "BSD"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,7 +8,12 @@ from .utils import create_test_yaml
 class MakeImageTests(TestCase):
     def test_direct_image(self):
         app = App(
-            "test", deployments={"image": "I0", "chart": "https://github.com/uptick/workforce"}
+            "test",
+            deployments={
+                "image": "I0",
+                "chart": "https://github.com/uptick/workforce",
+                "namespace": "rofl",
+            },
         )
         self.assertEqual(app.values["image"], "I0")
 
@@ -19,6 +24,7 @@ class MakeImageTests(TestCase):
                 "images": {"template": "image-template-{tag}"},
                 "chart": "https://uptick.com/uptick/workforce",
                 "image-tag": "I0",
+                "namespace": "rofl",
             },
         )
         self.assertEqual(app.values["image"], "image-template-I0")
@@ -30,6 +36,7 @@ class MakeImageTests(TestCase):
                 "images": {"template": "docker.io/uptick:{tag}"},
                 "chart": "https://uptick.com/uptick/workforce",
                 "image-tag": "qa-server-1asd1",
+                "namespace": "rofl",
             },
         )
         self.assertEqual(app.image_prefix, "qa-server")
@@ -37,9 +44,7 @@ class MakeImageTests(TestCase):
     def test_no_image_tag_is_valid(self):
         app = App(
             "test",
-            deployments={
-                "chart": "https://uptick.com/uptick/workforce",
-            },
+            deployments={"chart": "https://uptick.com/uptick/workforce", "namespace": "rofl"},
         )
         self.assertIsNone(app.values.get("image"))
 


### PR DESCRIPTION
Historically gitops commands were hardcoded to `workforce`.

With our move to RBAC + better namespaced apps we need gitops to run commands against specific namespaces.

We should be able to do `gitops bash some-app-installed-in-another-namespace`.
