### PR TITLE
feat/no-prefix

### DIFF
--- a/charts/gitops/Chart.yaml
+++ b/charts/gitops/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: GitOps Server Helm chart.
 name: gitops
-version: 0.9.10
+version: 0.9.11

--- a/gitops/__init__.py
+++ b/gitops/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from .utils.cli import success, warning
 
-__version__ = "0.9.10"
+__version__ = "0.9.11"
 
 
 # Checking gitops version matches cluster repo version.

--- a/gitops/common/app.py
+++ b/gitops/common/app.py
@@ -108,7 +108,10 @@ class App:
         """Gets the image prefix portion of {prefix}-{git hash}
         305686791668.dkr.ecr.ap-southeast-2.amazonaws.com/uptick:[yoink]-9f03ac80f3
 
-        eg: qa-server-12345 -> qa-server"""
+        eg: qa-server-12345 -> qa-server
+        """
+        if "-" not in self.image_tag:
+            return ""
         return self.image_tag.rsplit("-", 1)[0]
 
     @property

--- a/gitops/core.py
+++ b/gitops/core.py
@@ -75,6 +75,7 @@ def bump(
         app_name = app.name
         prev_image_tag = app.image_tag
         if image_tag is None:
+            # if we haven't specified a prefix
             if prefix is None:
                 new_image_prefix = app.image_prefix
             else:

--- a/gitops/utils/apps.py
+++ b/gitops/utils/apps.py
@@ -91,7 +91,7 @@ def get_apps(
         app = get_app_details(entry.name, load_secrets=load_secrets)
 
         pseudotags = [app.name, app.cluster]
-        if app.image:
+        if app.image and app.image_prefix:
             pseudotags.append(app.image_prefix)
 
         tags = set(app.tags + pseudotags)

--- a/gitops/utils/images.py
+++ b/gitops/utils/images.py
@@ -28,11 +28,20 @@ def get_latest_image(repository_name: str, prefix: str) -> str:
         maxResults=BATCH_SIZE,
     ):
         for image in ecr_response["imageDetails"]:
-            if prefix_tags := [tag for tag in image["imageTags"] if tag.startswith(prefix + "-")]:
-                results.append((prefix_tags[0], image["imagePushedAt"]))
+            if prefix != "":
+                if prefix_tags := [
+                    tag for tag in image["imageTags"] if tag.startswith(prefix + "-")
+                ]:
+                    results.append((prefix_tags[0], image["imagePushedAt"]))
+            else:
+                if prefix_tags := [tag for tag in image["imageTags"] if "-" not in tag]:
+                    results.append((prefix_tags[0], image["imagePushedAt"]))
 
     if not results:
-        print(f'No images with tag "{prefix}-*".')
+        if prefix:
+            print(f'No images found in repository: {repository_name} with tag "{prefix}-*".')
+        else:
+            print(f"No images found in repository: {repository_name}")
         return None
 
     latest_image_tag = sorted(results, key=lambda image: image[1], reverse=True)[0][0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitops"
-version = "0.9.10"
+version = "0.9.11"
 description = "Manage multiple apps across one or more k8s clusters."
 authors = ["Jarek Głowacki <jarekwg@gmail.com>"]
 license = "BSD"


### PR DESCRIPTION
This allows gitops to bump images without a prefix.

As we are moving towards CD we may not need branch based prefixes anymore.

This should allow us to do something like `gitops bump logbooks-staging` and not need a specific prefix.

To be even more specific;

We can now tag images like `ecr.repo.com/logbooks:ab1234` without including a prefix aka `ecr.repo.com/logbooks:main-1234a`.

When would we want to do this? In many use cases we don't care about a prefix (especially if we don't have QA servers or a branching strategy).

