### PR TITLE
fix(gitops-cli): prevent bumping to non-existent image prefix

### DIFF
--- a/charts/gitops/Chart.yaml
+++ b/charts/gitops/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: GitOps Server Helm chart.
 name: gitops
-version: 0.9.16
+version: 0.9.17

--- a/gitops/__init__.py
+++ b/gitops/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from . import monkeypatches  # NOQA
 from .utils.cli import success, warning
 
-__version__ = "0.9.16"
+__version__ = "0.9.17"
 
 
 # Checking gitops version matches cluster repo version.

--- a/gitops/core.py
+++ b/gitops/core.py
@@ -84,7 +84,13 @@ def bump(
             new_image_tag = get_latest_image(app.image_repository_name, new_image_prefix)
         else:
             new_image_tag = get_image(image_tag)
-        if new_image_tag != prev_image_tag:
+
+        if not new_image_tag:
+            print(
+                f"Skipping {colourise(app_name, Fore.LIGHTRED_EX)}: no image matching"
+                f" {colour_image(new_image_tag)}"
+            )
+        elif new_image_tag != prev_image_tag:
             print(
                 f"Bumping {colourise(app_name, Fore.LIGHTGREEN_EX)}: {colour_image(prev_image_tag)}"
                 f" -> {colour_image(new_image_tag)}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitops"
-version = "0.9.16"
+version = "0.9.17"
 description = "Manage multiple apps across one or more k8s clusters."
 authors = ["Jarek Głowacki <jarekwg@gmail.com>"]
 license = "BSD"


### PR DESCRIPTION
Added a trapdoor for missing image tags.

Nothing to fancy, just does a noop instead of bumping to prefix to `null`