### PR TITLE
fix: fix unsetenv to tolerate `environment: null`

### DIFF
--- a/gitops/core.py
+++ b/gitops/core.py
@@ -326,7 +326,7 @@ def unsetenv(ctx, filter, values, exclude=""):
         print(success_negative("Aborted."))
         return
     for app in apps:
-        environment = app.values.get("environment", {})
+        environment = app.values.get("environment") or {}
         for e in splitenvs:
             if e in environment:
                 del environment[e]


### PR DESCRIPTION
It should be treated identically as being unset/empty.