### PR TITLE
chore: speed up git checkout on large repos

### DIFF
--- a/gitops_server/utils/__init__.py
+++ b/gitops_server/utils/__init__.py
@@ -15,10 +15,11 @@ async def run(command, suppress_errors=False) -> RunOutput:
     exit_code = 0
     logger.info(f'Running "{command}".')
     proc = await asyncio.create_subprocess_shell(
-        command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        command,  # stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
     )
 
-    stdout, stderr = await proc.communicate()
+    stdout, stderr = b"", b""
+    await proc.communicate()
     exit_code = proc.returncode if proc.returncode not in (None, 128) else 1  # type: ignore
     if exit_code == 0:
         return RunOutput(exit_code=exit_code, output=stdout.decode())

--- a/gitops_server/utils/git.py
+++ b/gitops_server/utils/git.py
@@ -1,18 +1,21 @@
+import asyncio
 import logging
 import os
 import tempfile
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from opentelemetry.trace import get_tracer
 
 from . import run
 
 tracer = get_tracer(__name__)
-
-BASE_REPO_DIR = "/var/gitops/repos"
-
 logger = logging.getLogger("gitops")
+
+REPO_CACHE_DIR = Path("/tmp/gitops/repocache")
+REPO_CACHE: dict[str, Path] = {}
+repo_lock = asyncio.Semaphore(1)
 
 
 async def clone_repo(git_repo_url: str, path: str, sha: str | None = None):
@@ -22,7 +25,10 @@ async def clone_repo(git_repo_url: str, path: str, sha: str | None = None):
     url_with_oauth_token = git_repo_url.replace("://", f"://{os.environ['GITHUB_OAUTH_TOKEN'].strip()}@")
 
     with tracer.start_as_current_span("tempo_repo.clone_repo"):
-        await run(f"git clone {url_with_oauth_token} {path}; cd {path}; git checkout {sha}")
+        if sha:
+            await run(f"git clone --depth 100 {url_with_oauth_token} {path}; cd {path}; git checkout {sha}")
+        else:
+            await run(f"git clone --depth 100 {url_with_oauth_token} {path};")
 
     with tracer.start_as_current_span("temp_repo.git_crypt_unlock"):
         await run(f'cd {path}; git-crypt unlock {os.environ["GIT_CRYPT_KEY_FILE"]}')
@@ -32,6 +38,18 @@ async def clone_repo(git_repo_url: str, path: str, sha: str | None = None):
 async def temp_repo(git_repo_url: str, sha: str | None = None) -> AsyncGenerator[str, None]:
     """Checks out a git_repo_url to a temporary folder location. Returns temporary folder location"""
     with tracer.start_as_current_span("checkout_temp_repo"):
+        cache_path = REPO_CACHE_DIR / git_repo_url.split("/")[-1].split(".")[0]
+        if not (cache_path / ".git").exists():
+            logger.info("Repo %s not in cache, cloning", git_repo_url)
+            async with repo_lock:
+                if cache_path.exists():
+                    await run(f"rm -rf {cache_path}", suppress_errors=True)
+                if not cache_path.exists():
+                    cache_path.mkdir(parents=True)
+                REPO_CACHE[git_repo_url] = cache_path
+                await clone_repo(git_repo_url, path=str(cache_path))
         with tempfile.TemporaryDirectory() as temporary_folder_path:
-            await clone_repo(git_repo_url, path=temporary_folder_path, sha=sha)
+            await run(f"rm -rf {temporary_folder_path}", suppress_errors=True)
+            await run(f"cp -r {cache_path} {temporary_folder_path}")
+            await run(f"cd {temporary_folder_path};git fetch; git checkout {sha}")
             yield temporary_folder_path


### PR DESCRIPTION
Currently creating a tempo repo takes a very long time because we are cloning the complete repo each time (and git-crypt unlocking it).

Both of these steps combined takes upwards of 30seconds (multipled by 2) for each checkout.

This PR aims to speed it up by using a shallow fetched cached version of the repo as the base.

